### PR TITLE
Issue 1803 update emails to use delivery option

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -132,9 +132,9 @@ class DistributionsController < ApplicationController
     distribution = current_organization.distributions.find(params[:id])
 
     if !distribution.complete? && distribution.complete!
-      flash[:notice] = 'This distribution has been marked as being picked up!'
+      flash[:notice] = 'This distribution has been marked as being completed!'
     else
-      flash[:error] = 'Sorry, we encountered an error when trying to mark this distribution as being picked up'
+      flash[:error] = 'Sorry, we encountered an error when trying to mark this distribution as being completed'
     end
 
     redirect_back(fallback_location: distribution_path)

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -105,11 +105,7 @@ class DistributionsController < ApplicationController
 
     if result.success?
       if result.resend_notification? && @distribution.partner&.send_reminders
-        if result.issued_at_changed?
-          send_notification(current_organization.id, @distribution.id, subject: "Your Distribution's new Schedule Date is #{@distribution.issued_at}")
-        elsif result.delivery_method_changed?
-          send_notification(current_organization.id, @distribution.id, subject: "Your Distribution's new Delivery Method is #{@distribution.delivery_method.humanize}")
-        end
+        send_notification(current_organization.id, @distribution.id, subject: "Your Distribution Has Changed")
       end
       schedule_reminder_email(@distribution)
 

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -105,7 +105,11 @@ class DistributionsController < ApplicationController
 
     if result.success?
       if result.resend_notification? && @distribution.partner&.send_reminders
-        send_notification(current_organization.id, @distribution.id, subject: "Your Distribution New Schedule Date is #{@distribution.issued_at}")
+        if result.issued_at_changed?
+          send_notification(current_organization.id, @distribution.id, subject: "Your Distribution's new Schedule Date is #{@distribution.issued_at}")
+        elsif result.delivery_method_changed?
+          send_notification(current_organization.id, @distribution.id, subject: "Your Distribution's new Delivery Method is #{@distribution.delivery_method.humanize}")
+        end
       end
       schedule_reminder_email(@distribution)
 

--- a/app/services/distribution_update_service.rb
+++ b/app/services/distribution_update_service.rb
@@ -24,6 +24,14 @@ class DistributionUpdateService < DistributionService
   end
 
   def resend_notification?
-    @old_issued_at.to_date != @new_issued_at.to_date || @old_delivery_method != @new_delivery_method
+    issued_at_changed? || delivery_method_changed?
+  end
+
+  def issued_at_changed?
+    @old_issued_at.to_date != @new_issued_at.to_date
+  end
+
+  def delivery_method_changed?
+    @old_delivery_method != @new_delivery_method
   end
 end

--- a/app/services/distribution_update_service.rb
+++ b/app/services/distribution_update_service.rb
@@ -8,6 +8,7 @@ class DistributionUpdateService < DistributionService
   def call
     perform_distribution_service do
       @old_issued_at = distribution.issued_at
+      @old_delivery_method = distribution.delivery_method
       distribution.storage_location.increase_inventory(distribution.to_a)
       # Delete the line items -- they'll be replaced later
       distribution.line_items.each(&:destroy!)
@@ -16,12 +17,13 @@ class DistributionUpdateService < DistributionService
       distribution.update! @params
       distribution.reload
       @new_issued_at = distribution.issued_at
+      @new_delivery_method = distribution.delivery_method
       # Apply the new changes to the storage location inventory
       distribution.storage_location.decrease_inventory(distribution.to_a)
     end
   end
 
   def resend_notification?
-    @old_issued_at.to_date != @new_issued_at.to_date
+    @old_issued_at.to_date != @new_issued_at.to_date || @old_delivery_method != @new_delivery_method
   end
 end

--- a/app/views/distribution_mailer/partner_mailer.html.erb
+++ b/app/views/distribution_mailer/partner_mailer.html.erb
@@ -341,10 +341,10 @@
               <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                 <tr>
                   <td>
-                    <% delivery_method = (@distribution.delivery) ? 'delivered' : 'picked up' %>
+                    <% delivery_method = (@distribution.delivery?) ? 'delivered' : 'picked up' %>
                     <p><%= @partner.name %>,</p>
                     <p>Your diaper request has been approved and you can find attached to this email a copy of the distribution you will be receiving.</p>
-                    <p>Your distribution has been set to be <%= delivery_method %> on <%= @distribution.issued_at.strftime("%m/%d/%Y") %>.</p>
+                    <p>Your distribution has been set to be <b><%= delivery_method %></b> on <b><%= @distribution.issued_at.strftime("%m/%d/%Y") %></b>.</p>
                     <p>See you soon!</p>
                   </td>
                 <tr>

--- a/app/views/distribution_mailer/partner_mailer.html.erb
+++ b/app/views/distribution_mailer/partner_mailer.html.erb
@@ -341,9 +341,10 @@
               <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                 <tr>
                   <td>
+                    <% delivery_method = (@distribution.delivery) ? 'delivered' : 'picked up' %>
                     <p><%= @partner.name %>,</p>
                     <p>Your diaper request has been approved and you can find attached to this email a copy of the distribution you will be receiving.</p>
-                    <p>Your distribution has been set to be picked up on <%= @distribution.issued_at.strftime("%m/%d/%Y") %>.</p>
+                    <p>Your distribution has been set to be <%= delivery_method %> on <%= @distribution.issued_at.strftime("%m/%d/%Y") %>.</p>
                     <p>See you soon!</p>
                   </td>
                 <tr>

--- a/app/views/distribution_mailer/reminder_email.html.erb
+++ b/app/views/distribution_mailer/reminder_email.html.erb
@@ -6,6 +6,6 @@
   <body>
     <% delivery_method = (@distribution.delivery?) ? "delivery" : "pick up"%>
     <p>Hello <%= @partner.name %>,</p>
-    <p>This is a friendly reminder that tomorrow, <%= @distribution.issued_at.strftime("%A, %B #{@distribution.issued_at.day.ordinalize} %Y at %I:%M%p") %>, is your distribution <%= delivery_method %> date. </p>
+    <p>This is a friendly reminder that tomorrow, <b><%= @distribution.issued_at.strftime("%A, %B #{@distribution.issued_at.day.ordinalize} %Y at %I:%M%p") %></b>, is your distribution <b><%= delivery_method %></b> date. </p>
   </body>
 </html>

--- a/app/views/distribution_mailer/reminder_email.html.erb
+++ b/app/views/distribution_mailer/reminder_email.html.erb
@@ -4,7 +4,8 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
+    <% delivery_method = (@distribution.delivery?) ? "delivery" : "pick up"%>
     <p>Hello <%= @partner.name %>,</p>
-    <p>This is a friendly reminder that tomorrow, <%= @distribution.issued_at.strftime("%A, %B #{@distribution.issued_at.day.ordinalize} %Y at %I:%M%p") %>, is your distribution pick up date. </p>
+    <p>This is a friendly reminder that tomorrow, <%= @distribution.issued_at.strftime("%A, %B #{@distribution.issued_at.day.ordinalize} %Y at %I:%M%p") %>, is your distribution <%= delivery_method %> date. </p>
   </body>
 </html>

--- a/app/views/distributions/_pickup_day_row.html.erb
+++ b/app/views/distributions/_pickup_day_row.html.erb
@@ -5,13 +5,13 @@
   <td><%= pickup_day_row.line_items.total %></td>
   <td>
     <% if pickup_day_row.complete? %>
-      Picked up
+      Complete
     <% else %>
       Scheduled
     <% end %>
   </td>
   <td class="text-right">
-    <%= update_button_to picked_up_distribution_path(pickup_day_row), {text: "Pick up Complete", size: "xs"} if !pickup_day_row.complete? %>
+    <%= update_button_to picked_up_distribution_path(pickup_day_row), {text: "Distribution Complete", size: "xs"} if !pickup_day_row.complete? %>
     <%= view_button_to distribution_path(pickup_day_row) %>
   </td>
 </tr>

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -28,7 +28,7 @@
 
   <% unless @distribution.future? %>
     <div class="alert alert-warning" , role="alert">
-      The current date is past the date this distribution was scheduled.
+      The current date is past the date this distribution was scheduled for.
       Please be very careful when editing this record;
       the contents should match what was given to the recipient.
     </div>

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -28,7 +28,7 @@
 
   <% unless @distribution.future? %>
     <div class="alert alert-warning" , role="alert">
-      The current date is past the date this distribution was picked up.
+      The current date is past the date this distribution was scheduled.
       Please be very careful when editing this record;
       the contents should match what was given to the recipient.
     </div>

--- a/app/views/distributions/pickup_day.html.erb
+++ b/app/views/distributions/pickup_day.html.erb
@@ -2,9 +2,9 @@
   <div class="container-fluid">
     <div class="row mb-2">
       <div class="col-sm-6">
-        <% content_for :title, "Pick up Schedule for #{@selected_date.strftime("%B %e, %Y")}" %>
+        <% content_for :title, "Distribution Schedule for #{@selected_date.strftime("%B %e, %Y")}" %>
         <h1>
-          Pick up Schedule for <%= @selected_date.strftime("%B %e, %Y") %>
+          Distribution Schedule for <%= @selected_date.strftime("%B %e, %Y") %>
         </h1>
       </div>
       <div class="col-sm-6">

--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -77,7 +77,7 @@
             </table>
           </div>
           <div class="card-footer">
-            <%= update_button_to picked_up_distribution_path(@distribution), {text: "Pick up Complete", size: "md"} if @distribution.scheduled? %>
+            <%= update_button_to picked_up_distribution_path(@distribution), {text: "Distribution Complete", size: "md"} if @distribution.scheduled? %>
             <% if @distribution.future? || current_user.organization_admin? %>
               <%= edit_button_to edit_distribution_path(@distribution), {text: "Make a Correction", size: "md"} %>
             <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -315,7 +315,7 @@ end
                                       partner:          random_record_for_org(pdx_org, Partner),
                                       organization:     pdx_org,
                                       issued_at:        Faker::Date.between(from: 4.days.ago, to: Time.zone.today),
-                                      delivery_method: Distribution.delivery_methods.keys.sample)
+                                      delivery_method:  Distribution.delivery_methods.keys.sample)
 
   stored_inventory_items_sample.each do |stored_inventory_item|
     distribution_qty = rand(stored_inventory_item.quantity / 2)

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe DistributionMailer, type: :mailer do
         expect(mail.body.encoded).to match("distribution has been set to be delivered on")
       end
     end
-
   end
 
   describe "#reminder_email" do
@@ -42,6 +41,22 @@ RSpec.describe DistributionMailer, type: :mailer do
     it "renders the body with organizations email text" do
       expect(mail.body.encoded).to match("This is a friendly reminder")
       expect(mail.subject).to eq("PARTNER Distribution Reminder")
+    end
+
+    context "with deliver_method: :pick_up" do
+      it "renders the body with 'pick up' specified" do
+        distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: @partner, delivery_method: :pick_up)
+        mail = DistributionMailer.reminder_email(distribution.id)
+        expect(mail.body.encoded).to match("your distribution pick up date")
+      end
+    end
+
+    context "with deliver_method: :delivery" do
+      it "renders the body with 'delivery' specified" do
+        distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: @partner, delivery_method: :delivery)
+        mail = DistributionMailer.reminder_email(distribution.id)
+        expect(mail.body.encoded).to match("your distribution delivery date")
+      end
     end
   end
 end

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DistributionMailer, type: :mailer do
       it "renders the body with 'picked up' specified" do
         distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: @partner, delivery_method: :pick_up)
         mail = DistributionMailer.partner_mailer(@organization, distribution, 'test subject')
-        expect(mail.body.encoded).to match("distribution has been set to be picked up on")
+        expect(mail.body.encoded).to match("picked up")
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe DistributionMailer, type: :mailer do
       it "renders the body with 'delivered' specified" do
         distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: @partner, delivery_method: :delivery)
         mail = DistributionMailer.partner_mailer(@organization, distribution, 'test subject')
-        expect(mail.body.encoded).to match("distribution has been set to be delivered on")
+        expect(mail.body.encoded).to match("delivered")
       end
     end
   end
@@ -47,7 +47,7 @@ RSpec.describe DistributionMailer, type: :mailer do
       it "renders the body with 'pick up' specified" do
         distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: @partner, delivery_method: :pick_up)
         mail = DistributionMailer.reminder_email(distribution.id)
-        expect(mail.body.encoded).to match("your distribution pick up date")
+        expect(mail.body.encoded).to match("pick up")
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe DistributionMailer, type: :mailer do
       it "renders the body with 'delivery' specified" do
         distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: @partner, delivery_method: :delivery)
         mail = DistributionMailer.reminder_email(distribution.id)
-        expect(mail.body.encoded).to match("your distribution delivery date")
+        expect(mail.body.encoded).to match("delivery")
       end
     end
   end

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe DistributionMailer, type: :mailer do
   before do
     @organization.default_email_text = "Default email text example"
-    partner = create(:partner, name: 'PARTNER')
-    @distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: partner)
+    @partner = create(:partner, name: 'PARTNER')
+    @distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: @partner)
   end
 
   describe "#partner_mailer" do
@@ -17,6 +17,23 @@ RSpec.describe DistributionMailer, type: :mailer do
       expect(mail.body.encoded).to match("Distribution comment")
       expect(mail.subject).to eq("test subject from DEFAULT")
     end
+
+    context "with deliver_method: :pick_up" do
+      it "renders the body with 'picked up' specified" do
+        distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: @partner, delivery_method: :pick_up)
+        mail = DistributionMailer.partner_mailer(@organization, distribution, 'test subject')
+        expect(mail.body.encoded).to match("distribution has been set to be picked up on")
+      end
+    end
+
+    context "with deliver_method: :delivery" do
+      it "renders the body with 'delivered' specified" do
+        distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: @partner, delivery_method: :delivery)
+        mail = DistributionMailer.partner_mailer(@organization, distribution, 'test subject')
+        expect(mail.body.encoded).to match("distribution has been set to be delivered on")
+      end
+    end
+
   end
 
   describe "#reminder_email" do

--- a/spec/services/distribution_update_service_spec.rb
+++ b/spec/services/distribution_update_service_spec.rb
@@ -11,4 +11,20 @@ RSpec.describe DistributionUpdateService, type: :service do
       end.to change { distribution.storage_location.size }.by(8)
     end
   end
+
+  describe "resend_notification?" do
+    let!(:distribution) { FactoryBot.create(:distribution, :with_items, item_quantity: 10) }
+
+    it "changes the issue_date, resulting in resend_notification? = true" do
+      service = DistributionUpdateService.new(distribution, {issued_at: distribution.issued_at + 1.day})
+      service.call
+      assert service.resend_notification?
+    end
+
+    it "changes the delivery_method, resulting in resend_notification? = true" do
+      service = DistributionUpdateService.new(distribution, {delivery_method: :delivery})
+      service.call
+      assert service.resend_notification?
+    end
+  end
 end

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -211,13 +211,13 @@ RSpec.feature "Distributions", type: :system do
       it "can click on Edit button and a warning appears " do
         visit @url_prefix + "/distributions"
         click_on "Edit", match: :first
-        expect(page.find(".alert-warning")).to have_content "The current date is past the date this distribution was picked up."
+        expect(page.find(".alert-warning")).to have_content "The current date is past the date this distribution was scheduled for."
       end
 
       it "can be accessed directly" do
         visit @url_prefix + "/distributions/#{distribution.id}/edit"
         expect(page).to have_no_css(".alert-danger")
-        expect(page.find(".alert-warning")).to have_content "The current date is past the date this distribution was picked up."
+        expect(page.find(".alert-warning")).to have_content "The current date is past the date this distribution was scheduled for."
       end
     end
   end


### PR DESCRIPTION
Resolves #1803 <!--fill issue number-->

### Description
`delivery_method` was added as a field to distributions so we can specify whether a distribution is scheduled for "pick up" or "delivery". This PR updates the emails related to distributions to specify whether it is scheduled for pick up or delivery.
* Updates the partner and reminder email templates to specify if a distribution is a pick up or delivery.
* Updates various parts of the website to not use the specific term "pick up" in order to avoid confusion. 

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
* Unit tests

